### PR TITLE
Feature/5

### DIFF
--- a/packages/ui/src/Button/button.stories.tsx
+++ b/packages/ui/src/Button/button.stories.tsx
@@ -1,7 +1,5 @@
 import {colors} from '../constants/colors'
-
 import {Button} from '.'
-
 import type {ButtonProps} from '.'
 
 const meta = {

--- a/packages/ui/src/Button/button.stories.tsx
+++ b/packages/ui/src/Button/button.stories.tsx
@@ -41,7 +41,16 @@ export default meta
 export const 버튼 = ({color, backgroundColor, outlineColor, size, full}: ButtonProps) => {
     return (
         <div>
-            <Button color={color} backgroundColor={backgroundColor} outlineColor={outlineColor} size={size} full={full}>
+            <Button
+                color={color}
+                backgroundColor={backgroundColor}
+                outlineColor={outlineColor}
+                size={size}
+                full={full}
+                onClick={() => {
+                    console.log('버튼 클릭')
+                }}
+            >
                 버튼
             </Button>
         </div>

--- a/packages/ui/src/Button/index.tsx
+++ b/packages/ui/src/Button/index.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames/bind'
 import styles from './button.module.scss'
 import type {Color} from '../types/colors'
+import React from 'react'
 
 const cx = classNames.bind(styles)
 
@@ -11,6 +12,7 @@ interface ButtonProps {
     size?: 'sm' | 'md' | 'lg'
     outlineColor?: Color
     full?: boolean
+    onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
 }
 
 export function Button({
@@ -20,6 +22,7 @@ export function Button({
     outlineColor = undefined,
     size = 'md',
     full = false,
+    onClick,
 }: ButtonProps = {}) {
     return (
         <button
@@ -31,6 +34,7 @@ export function Button({
                 styles[size],
                 full ? styles.full : null,
             )}
+            onClick={onClick}
         >
             {children}
         </button>

--- a/packages/ui/src/Button/index.tsx
+++ b/packages/ui/src/Button/index.tsx
@@ -5,14 +5,13 @@ import React from 'react'
 
 const cx = classNames.bind(styles)
 
-interface ButtonProps {
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     children?: React.ReactNode
     color?: Color
     backgroundColor?: Color
     size?: 'sm' | 'md' | 'lg'
     outlineColor?: Color
     full?: boolean
-    onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
 }
 
 export function Button({
@@ -22,19 +21,19 @@ export function Button({
     outlineColor = undefined,
     size = 'md',
     full = false,
-    onClick,
-}: ButtonProps = {}) {
+    ...restProps
+}: ButtonProps) {
     return (
         <button
             className={cx(
-                styles.button,
+                'button',
                 `color-${color}`,
                 `bg-color-${backgroundColor}`,
                 `outline-color-${outlineColor}`,
-                styles[size],
-                full ? styles.full : null,
+                size,
+                full && 'full',
             )}
-            onClick={onClick}
+            {...restProps}
         >
             {children}
         </button>

--- a/packages/ui/src/Button/index.tsx
+++ b/packages/ui/src/Button/index.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 
 const cx = classNames.bind(styles)
 
-interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     children?: React.ReactNode
     color?: Color
     backgroundColor?: Color
@@ -31,7 +31,7 @@ export function Button({
                 `bg-color-${backgroundColor}`,
                 `outline-color-${outlineColor}`,
                 size,
-                full && 'full',
+                {full: full},
             )}
             {...restProps}
         >

--- a/packages/ui/src/Button/index.tsx
+++ b/packages/ui/src/Button/index.tsx
@@ -25,14 +25,14 @@ export function Button({
 }: ButtonProps) {
     return (
         <button
-            className={cx(
-                'button',
-                `color-${color}`,
-                `bg-color-${backgroundColor}`,
-                `outline-color-${outlineColor}`,
-                size,
-                {full: full},
-            )}
+            className={cx({
+                button: true,
+                [`color-${color}`]: color,
+                [`bg-color-${backgroundColor}`]: backgroundColor,
+                [`outline-color-${outlineColor}`]: outlineColor,
+                [`${size}`]: true,
+                full: full,
+            })}
             {...restProps}
         >
             {children}

--- a/packages/ui/src/Button/index.tsx
+++ b/packages/ui/src/Button/index.tsx
@@ -1,7 +1,5 @@
 import classNames from 'classnames/bind'
-
 import styles from './button.module.scss'
-
 import type {Color} from '../types/colors'
 
 const cx = classNames.bind(styles)

--- a/packages/ui/src/IconInput/iconInput.module.scss
+++ b/packages/ui/src/IconInput/iconInput.module.scss
@@ -1,0 +1,53 @@
+@forward '../styles/design-system.scss';
+
+.icon-input-container {
+    display: flex;
+    align-items: center;
+    width: auto;
+
+    &.full {
+        width: 100%;
+    }
+}
+
+.icon-input-wrapper {
+    display: flex;
+    align-items: center;
+    position: relative;
+    width: auto;
+    border-radius: 4px;
+
+    &.full {
+        width: 100%;
+    }
+}
+
+.clearable-btn {
+    position: absolute;
+    right: 24px;
+}
+
+.icon {
+    position: absolute;
+    top: 50%;
+    right: -10px;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.material-symbols-outlined {
+    font-variation-settings:
+        'FILL' 1,
+        'wght' 300,
+        'GRAD' 0,
+        'opsz' 20;
+    font-size: 14px;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transform: scale(0.8);
+    color: var(--adaptiveGrey200);
+}

--- a/packages/ui/src/IconInput/iconInput.stories.tsx
+++ b/packages/ui/src/IconInput/iconInput.stories.tsx
@@ -1,11 +1,11 @@
 import {colors} from '../constants/colors'
 import React from 'react'
-import {IconInput} from '.'
+import {IconInput, IconType} from '.'
 import type {InputProps} from '../Input'
 import {useState, useCallback} from 'react'
 
 interface IconInputProps extends InputProps {
-    icon?: string
+    icon: IconType
 }
 
 const meta = {
@@ -42,7 +42,7 @@ const meta = {
             control: {type: 'boolean'},
         },
         icon: {
-            control: {type: 'text'},
+            control: {type: 'select', options: ['search', 'cancel', 'close', 'block', 'check']},
         },
     },
 }
@@ -63,11 +63,10 @@ export const 아이콘_입력 = ({
 
     const handleOnChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         setText(e.target.value)
-        console.log('onChange')
     }, [])
 
     return (
-        <div style={{width: '300px'}}>
+        <div>
             <IconInput
                 placeholder={placeholder}
                 backgroundColor={backgroundColor}

--- a/packages/ui/src/IconInput/iconInput.stories.tsx
+++ b/packages/ui/src/IconInput/iconInput.stories.tsx
@@ -1,0 +1,85 @@
+import {colors} from '../constants/colors'
+import React from 'react'
+import {IconInput} from '.'
+import type {InputProps} from '../Input'
+import {useState, useCallback} from 'react'
+
+interface IconInputProps extends InputProps {
+    icon?: string
+}
+
+const meta = {
+    title: 'base/IconInput',
+    component: IconInput,
+    argTypes: {
+        backgroundColor: {
+            control: {
+                type: 'select',
+                options: Object.keys(colors),
+            },
+            description: '배경 색상',
+        },
+        outlineColor: {
+            control: {
+                type: 'select',
+                options: Object.keys(colors),
+            },
+            description: '테두리 색상',
+        },
+        variant: {
+            control: {type: 'select', options: ['filled', 'outline']},
+        },
+        placeholder: {
+            control: {type: 'text'},
+        },
+        full: {
+            control: {type: 'boolean'},
+        },
+        disabled: {
+            control: {type: 'boolean'},
+        },
+        clearable: {
+            control: {type: 'boolean'},
+        },
+        icon: {
+            control: {type: 'text'},
+        },
+    },
+}
+
+export default meta
+
+export const 아이콘_입력 = ({
+    placeholder,
+    backgroundColor,
+    outlineColor,
+    variant,
+    full,
+    disabled,
+    clearable,
+    icon,
+}: IconInputProps) => {
+    const [text, setText] = useState('')
+
+    const handleOnChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        setText(e.target.value)
+        console.log('onChange')
+    }, [])
+
+    return (
+        <div style={{width: '300px'}}>
+            <IconInput
+                placeholder={placeholder}
+                backgroundColor={backgroundColor}
+                outlineColor={outlineColor}
+                variant={variant}
+                full={full}
+                disabled={disabled}
+                onChange={handleOnChange}
+                value={text}
+                clearable={clearable}
+                icon={icon}
+            />
+        </div>
+    )
+}

--- a/packages/ui/src/IconInput/index.tsx
+++ b/packages/ui/src/IconInput/index.tsx
@@ -1,0 +1,26 @@
+import classNames from 'classnames/bind'
+import styles from './iconInput.module.scss'
+import React from 'react'
+import {Input, InputProps} from '../Input'
+
+const cx = classNames.bind(styles)
+
+export interface IconInputProps extends InputProps {
+    icon?: string
+}
+
+export function IconInput({icon, full, ...restProps}: IconInputProps) {
+    return (
+        <div className={cx('icon-input-container', full && 'full')}>
+            <div className={cx('icon-input-wrapper', full && 'full')}>
+                <Input {...restProps} full={full} isWithIcon={true} />
+
+                {icon ? (
+                    <span className={cx('icon')}>
+                        <span className={`material-symbols-outlined ${cx('material-symbols-outlined')}`}>{icon}</span>
+                    </span>
+                ) : null}
+            </div>
+        </div>
+    )
+}

--- a/packages/ui/src/IconInput/index.tsx
+++ b/packages/ui/src/IconInput/index.tsx
@@ -5,14 +5,16 @@ import {Input, InputProps} from '../Input'
 
 const cx = classNames.bind(styles)
 
+export type IconType = 'search' | 'cancel' | 'close' | 'block' | 'check'
+
 export interface IconInputProps extends InputProps {
-    icon?: string
+    icon: IconType
 }
 
 export function IconInput({icon, full, ...restProps}: IconInputProps) {
     return (
-        <div className={cx('icon-input-container', full && 'full')}>
-            <div className={cx('icon-input-wrapper', full && 'full')}>
+        <div className={cx('icon-input-container', {full: full})}>
+            <div className={cx('icon-input-wrapper', {full: full})}>
                 <Input {...restProps} full={full} isWithIcon={true} />
 
                 {icon ? (

--- a/packages/ui/src/IconInput/index.tsx
+++ b/packages/ui/src/IconInput/index.tsx
@@ -13,13 +13,20 @@ export interface IconInputProps extends InputProps {
 
 export function IconInput({icon, full, ...restProps}: IconInputProps) {
     return (
-        <div className={cx('icon-input-container', {full: full})}>
-            <div className={cx('icon-input-wrapper', {full: full})}>
+        <div
+            className={cx({
+                'icon-input-container': true,
+                full: full,
+            })}
+        >
+            <div className={cx({'icon-input-wrapper': true, full: full})}>
                 <Input {...restProps} full={full} isWithIcon={true} />
 
                 {icon ? (
-                    <span className={cx('icon')}>
-                        <span className={`material-symbols-outlined ${cx('material-symbols-outlined')}`}>{icon}</span>
+                    <span className={cx({icon: true})}>
+                        <span className={`material-symbols-outlined ${cx({'material-symbols-outlined': true})}`}>
+                            {icon}
+                        </span>
                     </span>
                 ) : null}
             </div>

--- a/packages/ui/src/Input/index.tsx
+++ b/packages/ui/src/Input/index.tsx
@@ -1,0 +1,41 @@
+import classNames from 'classnames/bind'
+import styles from './input.module.scss'
+import type {Color} from '../types/colors'
+import React from 'react'
+
+const cx = classNames.bind(styles)
+
+interface InputProps {
+    placeholder?: undefined | string
+    variant?: 'filled' | 'outline'
+    backgroundColor?: Color
+    outlineColor?: Color
+    full?: boolean
+    disabled?: boolean
+    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+}
+
+export function Input({
+    placeholder = undefined,
+    variant = 'filled',
+    backgroundColor = 'adaptiveBlue500',
+    outlineColor = undefined,
+    full = false,
+    disabled = false,
+    onChange,
+}: InputProps) {
+    return (
+        <input
+            placeholder={placeholder}
+            className={cx(
+                styles.input,
+                `bg-color-${backgroundColor}`,
+                `${variant == 'outline' ? `outline-color-${outlineColor}` : null}`,
+                `${variant == 'outline' ? `outline` : null}`,
+                full ? styles.full : null,
+            )}
+            disabled={disabled}
+            onChange={onChange}
+        />
+    )
+}

--- a/packages/ui/src/Input/index.tsx
+++ b/packages/ui/src/Input/index.tsx
@@ -35,25 +35,26 @@ export function Input({
     }
 
     return (
-        <div>
-            <input
-                placeholder={placeholder}
-                className={cx(
-                    'input',
-                    `bg-color-${backgroundColor}`,
-                    `${variant == 'outline' ? `outline-color-${outlineColor}` : null}`,
-                    `${variant == 'outline' ? `outline` : null}`,
-                    full && 'full',
+        <div className={cx('input-container', {full})}>
+            <div className={cx('input-wrapper')}>
+                <input
+                    placeholder={placeholder}
+                    className={cx(
+                        'input',
+                        `bg-color-${backgroundColor}`,
+                        `${variant == 'outline' ? `outline-color-${outlineColor}` : null}`,
+                        `${variant == 'outline' ? `outline` : null}`,
+                    )}
+                    onChange={onChange}
+                    value={value}
+                    {...restProps}
+                />
+                {value && clearable && (
+                    <button className={cx('clearable-btn')} onClick={clearInput}>
+                        <span className={`material-symbols-outlined ${cx('material-symbols-outlined')}`}>close</span>
+                    </button>
                 )}
-                onChange={onChange}
-                value={value}
-                {...restProps}
-            />
-            {value && clearable && (
-                <button className={cx('clearable-btn')} onClick={clearInput}>
-                    <span className={`material-symbols-outlined ${cx('material-symbols-outlined')}`}>close</span>
-                </button>
-            )}
+            </div>
         </div>
     )
 }

--- a/packages/ui/src/Input/index.tsx
+++ b/packages/ui/src/Input/index.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames/bind'
 import styles from './input.module.scss'
 import type {Color} from '../types/colors'
-import React from 'react'
+import React, {useCallback} from 'react'
 
 const cx = classNames.bind(styles)
 
@@ -27,12 +27,12 @@ export function Input({
     clearable = false,
     ...restProps
 }: InputProps) {
-    const clearInput = () => {
+    const clearInput = useCallback(() => {
         if (onChange) {
             const event = {target: {value: ''}} as React.ChangeEvent<HTMLInputElement>
             onChange(event)
         }
-    }
+    }, [onChange])
 
     return (
         <div className={cx('input-container', full && 'full')}>

--- a/packages/ui/src/Input/index.tsx
+++ b/packages/ui/src/Input/index.tsx
@@ -26,19 +26,29 @@ export function Input({
     onChange,
     value = undefined,
 }: InputProps) {
+    const clearInput = () => {
+        if (onChange) {
+            const event = {target: {value: ''}} as React.ChangeEvent<HTMLInputElement>
+            onChange(event)
+        }
+    }
+
     return (
-        <input
-            placeholder={placeholder}
-            className={cx(
-                styles.input,
-                `bg-color-${backgroundColor}`,
-                `${variant == 'outline' ? `outline-color-${outlineColor}` : null}`,
-                `${variant == 'outline' ? `outline` : null}`,
-                full ? styles.full : null,
-            )}
-            disabled={disabled}
-            onChange={onChange}
-            value={value}
-        />
+        <div>
+            <input
+                placeholder={placeholder}
+                className={cx(
+                    styles.input,
+                    `bg-color-${backgroundColor}`,
+                    `${variant == 'outline' ? `outline-color-${outlineColor}` : null}`,
+                    `${variant == 'outline' ? `outline` : null}`,
+                    full ? styles.full : null,
+                )}
+                disabled={disabled}
+                onChange={onChange}
+                value={value}
+            />
+            {value && !disabled && <button onClick={clearInput}>x</button>}
+        </div>
     )
 }

--- a/packages/ui/src/Input/index.tsx
+++ b/packages/ui/src/Input/index.tsx
@@ -5,26 +5,27 @@ import React from 'react'
 
 const cx = classNames.bind(styles)
 
-interface InputProps {
-    placeholder?: undefined | string
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+    placeholder?: string
     variant?: 'filled' | 'outline'
     backgroundColor?: Color
     outlineColor?: Color
     full?: boolean
     disabled?: boolean
-    value?: undefined | string
-    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+    value?: string
+    clearable?: boolean
 }
 
 export function Input({
-    placeholder = undefined,
+    placeholder = '',
     variant = 'filled',
     backgroundColor = 'adaptiveBlue500',
-    outlineColor = undefined,
+    outlineColor,
     full = false,
-    disabled = false,
     onChange,
-    value = undefined,
+    value = '',
+    clearable = false,
+    ...restProps
 }: InputProps) {
     const clearInput = () => {
         if (onChange) {
@@ -38,17 +39,21 @@ export function Input({
             <input
                 placeholder={placeholder}
                 className={cx(
-                    styles.input,
+                    'input',
                     `bg-color-${backgroundColor}`,
                     `${variant == 'outline' ? `outline-color-${outlineColor}` : null}`,
                     `${variant == 'outline' ? `outline` : null}`,
-                    full ? styles.full : null,
+                    full && 'full',
                 )}
-                disabled={disabled}
                 onChange={onChange}
                 value={value}
+                {...restProps}
             />
-            {value && !disabled && <button onClick={clearInput}>x</button>}
+            {value && clearable && (
+                <button className={styles.closeButton} onClick={clearInput}>
+                    <span className={`material-symbols-outlined ${cx('material-symbols-outlined')}`}>close</span>
+                </button>
+            )}
         </div>
     )
 }

--- a/packages/ui/src/Input/index.tsx
+++ b/packages/ui/src/Input/index.tsx
@@ -35,7 +35,7 @@ export function Input({
     }
 
     return (
-        <div className={cx('input-container', {full})}>
+        <div className={cx('input-container', full && 'full')}>
             <div className={cx('input-wrapper')}>
                 <input
                     placeholder={placeholder}

--- a/packages/ui/src/Input/index.tsx
+++ b/packages/ui/src/Input/index.tsx
@@ -50,7 +50,7 @@ export function Input({
                 {...restProps}
             />
             {value && clearable && (
-                <button className={styles.closeButton} onClick={clearInput}>
+                <button className={cx('clearable-btn')} onClick={clearInput}>
                     <span className={`material-symbols-outlined ${cx('material-symbols-outlined')}`}>close</span>
                 </button>
             )}

--- a/packages/ui/src/Input/index.tsx
+++ b/packages/ui/src/Input/index.tsx
@@ -5,7 +5,7 @@ import React, {useCallback} from 'react'
 
 const cx = classNames.bind(styles)
 
-interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
     placeholder?: string
     variant?: 'filled' | 'outline'
     backgroundColor?: Color
@@ -14,6 +14,7 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
     disabled?: boolean
     value?: string
     clearable?: boolean
+    isWithIcon?: boolean
 }
 
 export function Input({
@@ -25,6 +26,7 @@ export function Input({
     onChange,
     value = '',
     clearable = false,
+    isWithIcon = false,
     ...restProps
 }: InputProps) {
     const clearInput = useCallback(() => {
@@ -49,11 +51,14 @@ export function Input({
                     value={value}
                     {...restProps}
                 />
-                {value && clearable && (
-                    <button className={cx('clearable-btn')} onClick={clearInput}>
+                {value && clearable ? (
+                    <button
+                        className={cx(`${isWithIcon ? 'clearable-btn-with-icon' : 'clearable-btn-without-icon'}`)}
+                        onClick={clearInput}
+                    >
                         <span className={`material-symbols-outlined ${cx('material-symbols-outlined')}`}>close</span>
                     </button>
-                )}
+                ) : null}
             </div>
         </div>
     )

--- a/packages/ui/src/Input/index.tsx
+++ b/packages/ui/src/Input/index.tsx
@@ -12,6 +12,7 @@ interface InputProps {
     outlineColor?: Color
     full?: boolean
     disabled?: boolean
+    value?: undefined | string
     onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
 }
 
@@ -23,6 +24,7 @@ export function Input({
     full = false,
     disabled = false,
     onChange,
+    value = undefined,
 }: InputProps) {
     return (
         <input
@@ -36,6 +38,7 @@ export function Input({
             )}
             disabled={disabled}
             onChange={onChange}
+            value={value}
         />
     )
 }

--- a/packages/ui/src/Input/index.tsx
+++ b/packages/ui/src/Input/index.tsx
@@ -37,7 +37,7 @@ export function Input({
     }, [onChange])
 
     return (
-        <div className={cx('input-container', full && 'full')}>
+        <div className={cx('input-container', {full: full})}>
             <div className={cx('input-wrapper')}>
                 <input
                     placeholder={placeholder}

--- a/packages/ui/src/Input/index.tsx
+++ b/packages/ui/src/Input/index.tsx
@@ -37,26 +37,31 @@ export function Input({
     }, [onChange])
 
     return (
-        <div className={cx('input-container', {full: full})}>
+        <div className={cx({'input-container': true, full: full})}>
             <div className={cx('input-wrapper')}>
                 <input
                     placeholder={placeholder}
-                    className={cx(
-                        'input',
-                        `bg-color-${backgroundColor}`,
-                        `${variant == 'outline' ? `outline-color-${outlineColor}` : null}`,
-                        `${variant == 'outline' ? `outline` : null}`,
-                    )}
+                    className={cx({
+                        input: true,
+                        [`bg-color-${backgroundColor}`]: backgroundColor,
+                        [`outline-color-${outlineColor}`]: variant === 'outline',
+                        outline: variant === 'outline',
+                    })}
                     onChange={onChange}
                     value={value}
                     {...restProps}
                 />
                 {value && clearable ? (
                     <button
-                        className={cx(`${isWithIcon ? 'clearable-btn-with-icon' : 'clearable-btn-without-icon'}`)}
+                        className={cx({
+                            'clearable-btn-with-icon': isWithIcon,
+                            'clearable-btn-without-icon': !isWithIcon,
+                        })}
                         onClick={clearInput}
                     >
-                        <span className={`material-symbols-outlined ${cx('material-symbols-outlined')}`}>close</span>
+                        <span className={`material-symbols-outlined ${cx({'material-symbols-outlined': true})}`}>
+                            close
+                        </span>
                     </button>
                 ) : null}
             </div>

--- a/packages/ui/src/Input/input.module.scss
+++ b/packages/ui/src/Input/input.module.scss
@@ -20,3 +20,22 @@
         border: 1px solid black;
     }
 }
+
+.material-symbols-outlined {
+    font-variation-settings:
+        'FILL' 1,
+        // ✅ 배경 채움
+        'wght' 600,
+        // ✅ 글자 굵기
+        'GRAD' 0,
+        // ✅ 두께
+        'opsz' 24; // ✅ 옵티컬 사이즈
+
+    font-size: 14px; // ✅ 아이콘 크기 줄이기
+    line-height: 1; // ✅ 아이콘의 세로 정렬 조정
+    display: flex; // ✅ flex를 추가해 더 정확한 정렬
+    align-items: center;
+    justify-content: center;
+    transform: scale(0.8); // ✅ 아이콘 자체 크기 줄이기
+    color: red; // ✅ 아이콘 색상 명확히 지정
+}

--- a/packages/ui/src/Input/input.module.scss
+++ b/packages/ui/src/Input/input.module.scss
@@ -1,17 +1,45 @@
 @forward '../styles/design-system.scss';
 
+.input-container {
+    display: inline-block;
+    width: auto;
+
+    &.full {
+        display: block;
+        width: 100%;
+    }
+}
+
+.input-wrapper {
+    position: relative;
+    width: 100%;
+}
+
 .input {
     border-radius: 4px;
-    padding: 4px 8px;
+    padding: 4px 8px 4px 8px;
     font-size: 13px;
     line-height: 20px;
     outline: none;
-    width: 150px;
-    height: 25px;
+    width: 100%;
+    height: 28px;
 }
 
-.full {
-    width: 100%;
+.clearable-btn {
+    position: absolute;
+    top: 50%;
+    right: -10px;
+    transform: translateY(-50%);
+    background-color: var(--adaptiveGrey800);
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    width: 15px;
+    height: 15px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
 }
 
 .outline {
@@ -23,18 +51,14 @@
 .material-symbols-outlined {
     font-variation-settings:
         'FILL' 1,
-        // ✅ 배경 채움
-        'wght' 600,
-        // ✅ 글자 굵기
+        'wght' 300,
         'GRAD' 0,
-        // ✅ 두께
-        'opsz' 24; // ✅ 옵티컬 사이즈
-
-    font-size: 14px; // ✅ 아이콘 크기 줄이기
-    line-height: 1; // ✅ 아이콘의 세로 정렬 조정
-    display: flex; // ✅ flex를 추가해 더 정확한 정렬
+        'opsz' 20;
+    font-size: 14px;
+    line-height: 1;
+    display: flex;
     align-items: center;
     justify-content: center;
-    transform: scale(0.8); // ✅ 아이콘 자체 크기 줄이기
-    color: red; // ✅ 아이콘 색상 명확히 지정
+    transform: scale(0.6);
+    color: var(--adaptiveGrey900);
 }

--- a/packages/ui/src/Input/input.module.scss
+++ b/packages/ui/src/Input/input.module.scss
@@ -12,7 +12,6 @@
 
 .full {
     width: 100%;
-    height: 100%;
 }
 
 .outline {

--- a/packages/ui/src/Input/input.module.scss
+++ b/packages/ui/src/Input/input.module.scss
@@ -25,7 +25,24 @@
     height: 28px;
 }
 
-.clearable-btn {
+.clearable-btn-with-icon {
+    position: absolute;
+    top: 50%;
+    right: 15px;
+    transform: translateY(-50%);
+    background-color: var(--adaptiveGrey800);
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    width: 15px;
+    height: 15px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+}
+
+.clearable-btn-without-icon {
     position: absolute;
     top: 50%;
     right: -10px;

--- a/packages/ui/src/Input/input.module.scss
+++ b/packages/ui/src/Input/input.module.scss
@@ -1,0 +1,22 @@
+@forward '../styles/design-system.scss';
+
+.input {
+    border-radius: 4px;
+    padding: 4px 8px;
+    font-size: 13px;
+    line-height: 20px;
+    outline: none;
+    width: 150px;
+    height: 25px;
+}
+
+.full {
+    width: 100%;
+    height: 100%;
+}
+
+.outline {
+    &:focus {
+        border: 1px solid black;
+    }
+}

--- a/packages/ui/src/Input/input.stories.tsx
+++ b/packages/ui/src/Input/input.stories.tsx
@@ -32,12 +32,15 @@ const meta = {
         disabled: {
             control: {type: 'boolean'},
         },
+        value: {
+            control: {type: 'text'},
+        },
     },
 }
 
 export default meta
 
-export const 입력 = ({placeholder, backgroundColor, outlineColor, variant, full, disabled}: InputPros) => {
+export const 입력 = ({placeholder, backgroundColor, outlineColor, variant, full, disabled, value}: InputPros) => {
     return (
         <div>
             <Input
@@ -48,6 +51,7 @@ export const 입력 = ({placeholder, backgroundColor, outlineColor, variant, ful
                 full={full}
                 disabled={disabled}
                 onChange={(e) => console.log(e.target.value)}
+                value={value}
             />
         </div>
     )

--- a/packages/ui/src/Input/input.stories.tsx
+++ b/packages/ui/src/Input/input.stories.tsx
@@ -1,6 +1,7 @@
 import {colors} from '../constants/colors'
 import {Input} from '.'
 import type {InputPros} from '.'
+import {useState} from 'react'
 
 const meta = {
     title: 'base/Input',
@@ -32,17 +33,20 @@ const meta = {
         disabled: {
             control: {type: 'boolean'},
         },
-        value: {
-            control: {type: 'text'},
-        },
     },
 }
 
 export default meta
 
-export const 입력 = ({placeholder, backgroundColor, outlineColor, variant, full, disabled, value}: InputPros) => {
+export const 입력 = ({placeholder, backgroundColor, outlineColor, variant, full, disabled}: InputPros) => {
+    const [text, setText] = useState('')
+    const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setText(e.target.value)
+        console.log('onChange')
+    }
     return (
         <div>
+            {text}
             <Input
                 placeholder={placeholder}
                 backgroundColor={backgroundColor}
@@ -50,8 +54,8 @@ export const 입력 = ({placeholder, backgroundColor, outlineColor, variant, ful
                 variant={variant}
                 full={full}
                 disabled={disabled}
-                onChange={(e) => console.log(e.target.value)}
-                value={value}
+                onChange={handleOnChange}
+                value={text}
             />
         </div>
     )

--- a/packages/ui/src/Input/input.stories.tsx
+++ b/packages/ui/src/Input/input.stories.tsx
@@ -1,6 +1,6 @@
 import {colors} from '../constants/colors'
 import {Input} from '.'
-import type {InputPros} from '.'
+import type {InputProps} from '.'
 import {useState, useCallback} from 'react'
 
 const meta = {
@@ -41,11 +41,10 @@ const meta = {
 
 export default meta
 
-export const 입력 = ({placeholder, backgroundColor, outlineColor, variant, full, disabled, clearable}: InputPros) => {
+export const 입력 = ({placeholder, backgroundColor, outlineColor, variant, full, disabled, clearable}: InputProps) => {
     const [text, setText] = useState('')
     const handleOnChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         setText(e.target.value)
-        console.log('onChange')
     }, [])
 
     return (

--- a/packages/ui/src/Input/input.stories.tsx
+++ b/packages/ui/src/Input/input.stories.tsx
@@ -1,0 +1,54 @@
+import {colors} from '../constants/colors'
+import {Input} from '.'
+import type {InputPros} from '.'
+
+const meta = {
+    title: 'base/Input',
+    component: Input,
+    argTypes: {
+        backgroundColor: {
+            control: {
+                type: 'select',
+                options: Object.keys(colors),
+            },
+            description: '버튼 색상',
+        },
+        outlineColor: {
+            control: {
+                type: 'select',
+                options: Object.keys(colors),
+            },
+            description: '테투리 색상',
+        },
+        variant: {
+            control: {type: 'select', options: ['filled', 'outline']},
+        },
+        placeholder: {
+            control: {type: 'text'},
+        },
+        full: {
+            control: {type: 'boolean'},
+        },
+        disabled: {
+            control: {type: 'boolean'},
+        },
+    },
+}
+
+export default meta
+
+export const 입력 = ({placeholder, backgroundColor, outlineColor, variant, full, disabled}: InputPros) => {
+    return (
+        <div>
+            <Input
+                placeholder={placeholder}
+                backgroundColor={backgroundColor}
+                outlineColor={outlineColor}
+                variant={variant}
+                full={full}
+                disabled={disabled}
+                onChange={(e) => console.log(e.target.value)}
+            />
+        </div>
+    )
+}

--- a/packages/ui/src/Input/input.stories.tsx
+++ b/packages/ui/src/Input/input.stories.tsx
@@ -1,7 +1,7 @@
 import {colors} from '../constants/colors'
 import {Input} from '.'
 import type {InputPros} from '.'
-import {useState} from 'react'
+import {useState, useCallback} from 'react'
 
 const meta = {
     title: 'base/Input',
@@ -43,10 +43,11 @@ export default meta
 
 export const 입력 = ({placeholder, backgroundColor, outlineColor, variant, full, disabled, clearable}: InputPros) => {
     const [text, setText] = useState('')
-    const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const handleOnChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         setText(e.target.value)
         console.log('onChange')
-    }
+    }, [])
+
     return (
         <div>
             <Input

--- a/packages/ui/src/Input/input.stories.tsx
+++ b/packages/ui/src/Input/input.stories.tsx
@@ -33,12 +33,15 @@ const meta = {
         disabled: {
             control: {type: 'boolean'},
         },
+        clearable: {
+            control: {type: 'boolean'},
+        },
     },
 }
 
 export default meta
 
-export const 입력 = ({placeholder, backgroundColor, outlineColor, variant, full, disabled}: InputPros) => {
+export const 입력 = ({placeholder, backgroundColor, outlineColor, variant, full, disabled, clearable}: InputPros) => {
     const [text, setText] = useState('')
     const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setText(e.target.value)
@@ -56,6 +59,7 @@ export const 입력 = ({placeholder, backgroundColor, outlineColor, variant, ful
                 disabled={disabled}
                 onChange={handleOnChange}
                 value={text}
+                clearable={clearable}
             />
         </div>
     )

--- a/packages/ui/src/Input/input.stories.tsx
+++ b/packages/ui/src/Input/input.stories.tsx
@@ -49,7 +49,6 @@ export const 입력 = ({placeholder, backgroundColor, outlineColor, variant, ful
     }
     return (
         <div>
-            {text}
             <Input
                 placeholder={placeholder}
                 backgroundColor={backgroundColor}

--- a/packages/ui/src/Text/index.tsx
+++ b/packages/ui/src/Text/index.tsx
@@ -11,5 +11,15 @@ export interface TextProps {
     bold?: boolean
 }
 export function Text({children, color = 'adaptiveGrey900', size = 'body1', bold = false}: TextProps = {}) {
-    return <p className={cx(`color-${color}`, styles[size], bold ? 'bold' : null)}>{children}</p>
+    return (
+        <p
+            className={cx({
+                [`color-${color}`]: color,
+                [`${size}`]: true,
+                bold: bold,
+            })}
+        >
+            {children}
+        </p>
+    )
 }

--- a/packages/ui/src/Text/index.tsx
+++ b/packages/ui/src/Text/index.tsx
@@ -4,12 +4,12 @@ import type {Color} from '../types/colors'
 
 const cx = classNames.bind(styles)
 
-interface TextProps {
+export interface TextProps {
     children?: React.ReactNode
     color?: Color
     size?: 'title1' | 'title2' | 'title3' | 'title4' | 'body1' | 'body2' | 'body3' | 'body4'
     bold?: boolean
 }
 export function Text({children, color = 'adaptiveGrey900', size = 'body1', bold = false}: TextProps = {}) {
-    return <p className={cx(`color-${color}`, styles[size], bold ? styles.bold : null)}>{children}</p>
+    return <p className={cx(`color-${color}`, styles[size], bold ? 'bold' : null)}>{children}</p>
 }

--- a/packages/ui/src/Text/index.tsx
+++ b/packages/ui/src/Text/index.tsx
@@ -1,0 +1,15 @@
+import classNames from 'classnames/bind'
+import styles from './text.module.scss'
+import type {Color} from '../types/colors'
+
+const cx = classNames.bind(styles)
+
+interface TextProps {
+    children?: React.ReactNode
+    color?: Color
+    size?: 'title1' | 'title2' | 'title3' | 'title4' | 'body1' | 'body2' | 'body3' | 'body4'
+    bold?: boolean
+}
+export function Text({children, color = 'adaptiveGrey900', size = 'body1', bold = false}: TextProps = {}) {
+    return <p className={cx(`color-${color}`, styles[size], bold ? styles.bold : null)}>{children}</p>
+}

--- a/packages/ui/src/Text/text.module.scss
+++ b/packages/ui/src/Text/text.module.scss
@@ -1,0 +1,37 @@
+@forward '../styles/design-system.scss';
+
+.title1 {
+    font-size: 28px;
+}
+
+.title2 {
+    font-size: 24px;
+}
+
+.title3 {
+    font-size: 20px;
+}
+
+.title4 {
+    font-size: 18px;
+}
+
+.body1 {
+    font-size: 16px;
+}
+
+.body2 {
+    font-size: 14px;
+}
+
+.body3 {
+    font-size: 13px;
+}
+
+.body4 {
+    font-size: 11px;
+}
+
+.bold {
+    font-weight: bold;
+}

--- a/packages/ui/src/Text/text.stories.tsx
+++ b/packages/ui/src/Text/text.stories.tsx
@@ -1,0 +1,36 @@
+import {colors} from '../constants/colors'
+import {Text} from '.'
+import type {TextProps} from '.'
+
+const meta = {
+    title: 'base/Text',
+    component: Text,
+    argTypes: {
+        color: {
+            control: {
+                type: 'select',
+                options: Object.keys(colors),
+            },
+            description: '텍스트 색상',
+        },
+        size: {
+            control: {
+                type: 'select',
+                options: ['title1', 'title2', 'title3', 'title4', 'body1', 'body2', 'body3', 'body4'],
+            },
+        },
+        bold: {
+            control: {type: 'boolean'},
+        },
+    },
+}
+
+export default meta
+
+export const 텍스트 = ({color, size, bold}: TextProps) => {
+    return (
+        <Text color={color} size={size} bold={bold}>
+            텍스트
+        </Text>
+    )
+}

--- a/packages/ui/src/styles/design-system.scss
+++ b/packages/ui/src/styles/design-system.scss
@@ -3,3 +3,5 @@
 @use './base';
 @use './variables';
 @use './mixin' as *;
+
+@import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined');


### PR DESCRIPTION
## 📌 작업 내용
- `Button` 컴포넌트의 Props 인터페이스를 `React.ButtonHTMLAttributes<HTMLButtonElement>`를 확장하는 방식으로 변경
- `Input` 디자인 컴포넌트 구현
  - `outline` / `filled` 속성 추가
  - `clearable` 속성 추가
  - `full` 속성 추가
  - `color` 속성 추가
- `Text` 디자인 컴포넌트 구현
  - `color` 속성 추가
  - `size` 속성 추가
  - `bold` 속성 추가
- `Material Symbols Icon` 추가

## 📎 참고 사항
- `Button`, `Input`, `Text` 컴포넌트의 사용 예시는 Storybook 또는 테스트 코드에서 확인 가능 🙌
